### PR TITLE
Update .gitignore to exclude generated files and outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,13 @@ sampledata_vctk_DEMAND
 training.h5
 
 DNS-Challenge
+
+#Kristoffers additions
+# Audio analysis and output files
+audio_analysis.png
+feature_test.raw
+percepnet_output.pcm
+
+# Generated C files
+nnet_data.c
+src/nnet_data.cpp


### PR DESCRIPTION
This is the first version of the Unofficial PercepNet code i got to work. While not fully trained, it should have enough saved checkpoints to see that it is actually working. To get it to work, you will need to follow the guide found in the original repository.